### PR TITLE
feat(seo): sitemap completion, robots.txt hardening & noindex (#16)

### DIFF
--- a/src/app/(user)/privacy-settings/layout.tsx
+++ b/src/app/(user)/privacy-settings/layout.tsx
@@ -1,0 +1,15 @@
+// src/app/(user)/privacy-settings/layout.tsx
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Settings — UnTelevised Media',
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+  },
+};
+
+export default function PrivacySettingsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(user)/sitemap.ts
+++ b/src/app/(user)/sitemap.ts
@@ -92,6 +92,15 @@ export default async function sitemap(): Promise<
       priority: 0.7,
     }));
 
+  const timelineURLs = allNews
+    .filter((item) => item._type === 'timeline')
+    .map((timeline) => ({
+      url: `https://www.untelevised.media/timeline/${timeline.slug.current}/`,
+      lastModified: timeline._updatedAt,
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    }));
+
   return [
     // Homepage — highest priority
     {
@@ -109,7 +118,8 @@ export default async function sitemap(): Promise<
     ...songURLs,
     ...musicArtistURLs,
     ...albumURLs,
-    // Static section pages
+    ...timelineURLs,
+    // Static section pages — music
     {
       url: 'https://www.untelevised.media/lyrics/',
       lastModified: new Date(),
@@ -122,6 +132,7 @@ export default async function sitemap(): Promise<
       changeFrequency: 'weekly' as const,
       priority: 0.8,
     },
+    // Static section pages — editorial & info
     {
       url: 'https://www.untelevised.media/about/',
       lastModified: new Date(),
@@ -135,16 +146,48 @@ export default async function sitemap(): Promise<
       priority: 0.5,
     },
     {
+      url: 'https://www.untelevised.media/past-events/',
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    },
+    {
+      url: 'https://www.untelevised.media/timelines/',
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    },
+    // Static section pages — engagement & conversion
+    {
+      url: 'https://www.untelevised.media/join/',
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    },
+    {
       url: 'https://www.untelevised.media/donate/',
       lastModified: new Date(),
       changeFrequency: 'monthly' as const,
       priority: 0.4,
     },
     {
-      url: 'https://www.untelevised.media/past-events/',
+      url: 'https://www.untelevised.media/support/',
       lastModified: new Date(),
-      changeFrequency: 'weekly' as const,
-      priority: 0.6,
+      changeFrequency: 'monthly' as const,
+      priority: 0.3,
+    },
+    // Static section pages — source protection
+    {
+      url: 'https://www.untelevised.media/secure-contact/',
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.4,
+    },
+    {
+      url: 'https://www.untelevised.media/whistleblower/',
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.5,
     },
   ];
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,8 +9,8 @@ export default function robots(): MetadataRoute.Robots {
       // All standard crawlers — allow everything except studio and API
       {
         userAgent: '*',
-        allow: '/',
-        disallow: ['/studio/', '/api/'],
+        allow: ['/', '/feed.xml'],
+        disallow: ['/studio/', '/api/', '/privacy-settings', '/reading-list', '/unlock'],
       },
       // Explicitly allow major AI crawlers for AEO (AI answer engine optimization)
       { userAgent: 'GPTBot', allow: '/' },

--- a/src/util/getAllUrls.ts
+++ b/src/util/getAllUrls.ts
@@ -55,6 +55,13 @@ export default async function getAllURLs() {
       slug,
     }`;
 
+  const queryTimelines = groq`
+    *[_type == "timeline"] {
+      ...,
+      title,
+      slug,
+    }`;
+
   try {
     const articles = await sanityClient.fetch(queryAllArticleUrls);
     const liveEvents = await sanityClient.fetch(queryAllLiveEventUrls);
@@ -64,6 +71,7 @@ export default async function getAllURLs() {
     const songs = await sanityClient.fetch(querySongs);
     const musicArtists = await sanityClient.fetch(queryMusicArtists);
     const albums = await sanityClient.fetch(queryAlbums);
+    const timelines = await sanityClient.fetch(queryTimelines);
 
     const allNews = [
       ...articles,
@@ -74,6 +82,7 @@ export default async function getAllURLs() {
       ...songs,
       ...musicArtists,
       ...albums,
+      ...timelines,
     ];
 
     return allNews;


### PR DESCRIPTION
## Summary

- Added 5 missing static pages to sitemap: `/timelines`, `/join`, `/support`, `/secure-contact`, `/whistleblower`
- Added dynamic timeline individual pages (`/timeline/[slug]`) via new Sanity query in `getAllURLs.ts`
- Fixed `/past-events` priority from 0.6 → 0.7 (it's a key archive page)
- Hardened `robots.ts`: added `Disallow` for `/privacy-settings`, `/reading-list`, `/unlock`; added explicit `Allow: /feed.xml` (prep for RSS issue #9)
- Added `privacy-settings/layout.tsx` exporting `noindex` metadata (required because the page itself is `'use client'`)

## Deliverables Checklist (from #16)

### Sitemap Static Pages
- [x] `/about` — already present
- [x] `/staff` — already present
- [x] `/past-events` — already present (priority corrected)
- [x] `/timelines` — added
- [x] `/donate` — already present
- [x] `/join` — added
- [x] `/support` — added
- [x] `/secure-contact` — added
- [x] `/whistleblower` — added
- [ ] `/careers` — deferred until issue #17 (Careers Page) is built

### Sitemap Dynamic Pages
- [x] Articles use `_updatedAt` with smart priority tiering
- [x] Live events, authors, categories, policies, songs, music artists, albums — all present
- [x] Timeline individual pages — added via new `queryTimelines` in `getAllURLs.ts`
- [x] `/privacy-settings`, `/reading-list`, `/unlock` NOT in sitemap

### Robots.txt
- [x] `Allow: /` — present
- [x] `Disallow: /studio/` — present
- [x] `Disallow: /api/` — present
- [x] `Disallow: /privacy-settings` — added
- [x] `Disallow: /reading-list` — added
- [x] `Disallow: /unlock` — added
- [x] `Allow: /feed.xml` — added
- [x] AI crawler explicit allowances (GPTBot, ClaudeBot, etc.) — already present

### Noindex Tags
- [x] `/privacy-settings` — `robots: { index: false, follow: false, nocache: true }` via layout.tsx
- [ ] `/search` — page is empty directory, deferred until search is built (#21)

## Test plan

- [x] `pnpm build` passes
- [x] `/sitemap.xml` returns valid XML with new static pages present
- [x] `/robots.txt` shows new Disallow entries
- [ ] `<meta name="robots" content="noindex">` present on `/privacy-settings`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)