### PR TITLE
feat(sources): Source Transparency Panel — standalone source documents (#24)

### DIFF
--- a/scripts/migrate-sources.mjs
+++ b/scripts/migrate-sources.mjs
@@ -1,0 +1,109 @@
+/**
+ * Migration: inline article sources → standalone `source` documents
+ *
+ * For each article with old-format sources ({ label, url } inline objects),
+ * this script:
+ *   1. Creates a new `source` document for each entry
+ *   2. Patches the article's `sources` field to an array of references
+ *   3. Logs a dry-run summary before writing anything
+ *
+ * Run:  node scripts/migrate-sources.mjs
+ * Dry:  node scripts/migrate-sources.mjs --dry-run
+ */
+
+import { createClient } from '@sanity/client';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const client = createClient({
+  projectId: 'ypejdt32',
+  dataset: 'articles',
+  apiVersion: '2024-01-01',
+  token:
+    'skhhJyYQtW9pwQmkAYWIoOcvk5LHynaefsPu6ygqa3AaClORQsWBUEQKTChM9ZsjSnzbNaJnfXHkMPhwwsmko3PlGH0An3Rbq5lQ8i8EvwcGSKpStTpZzExXLkLazrwp0j5n5Kj3QyjHCLlEBe75jqJu8B1DMWrnZ1prUL1fFhLL1QmwBink',
+  useCdn: false,
+});
+
+// Fetch all articles that still have old-format inline sources
+const articles = await client.fetch(
+  `*[_type == 'article' && defined(sources) && count(sources[_type == 'object']) > 0]
+   | order(_createdAt desc) {
+     _id,
+     title,
+     sources
+   }`
+);
+
+if (articles.length === 0) {
+  console.log('✅ No articles with old-format inline sources found. Nothing to migrate.');
+  process.exit(0);
+}
+
+console.log(`\nFound ${articles.length} article(s) with inline sources to migrate:\n`);
+articles.forEach((a) => console.log(`  • [${a._id}] ${a.title} (${a.sources.length} sources)`));
+
+if (DRY_RUN) {
+  console.log('\n⚠️  DRY RUN — no changes will be written.\n');
+}
+
+let totalCreated = 0;
+let totalPatched = 0;
+
+for (const article of articles) {
+  console.log(`\n──────────────────────────────────────────`);
+  console.log(`Article: ${article.title}`);
+  console.log(`ID:      ${article._id}`);
+  console.log(`Sources: ${article.sources.length}`);
+
+  const references = [];
+
+  for (const src of article.sources) {
+    // Skip if already a reference (safety guard)
+    if (src._type === 'reference') {
+      console.log(`  ↩  Already a reference: ${src._ref} — skipping`);
+      references.push({ _type: 'reference', _ref: src._ref, _key: src._key });
+      continue;
+    }
+
+    const sourceDoc = {
+      _type: 'source',
+      label: src.label ?? 'Untitled Source',
+      type: 'other', // Default — editors can update in Studio
+      ...(src.url ? { url: src.url } : {}),
+      isAnonymous: false,
+    };
+
+    console.log(`  + Creating source: "${sourceDoc.label}" ${src.url ? `→ ${src.url}` : '(no URL)'}`);
+
+    if (!DRY_RUN) {
+      const created = await client.create(sourceDoc);
+      references.push({ _type: 'reference', _ref: created._id, _key: src._key });
+      totalCreated++;
+    } else {
+      // Placeholder ref for dry-run logging
+      references.push({ _type: 'reference', _ref: `[new-source-id]`, _key: src._key });
+    }
+  }
+
+  console.log(`  → Patching article sources to ${references.length} reference(s)…`);
+
+  if (!DRY_RUN) {
+    await client
+      .patch(article._id)
+      .set({ sources: references })
+      .commit({ autoGenerateArrayKeys: false });
+    totalPatched++;
+  }
+}
+
+console.log(`\n══════════════════════════════════════════`);
+if (DRY_RUN) {
+  console.log('DRY RUN complete — no changes written.');
+  console.log(`Would create ${articles.flatMap((a) => a.sources).length} source documents.`);
+  console.log(`Would patch ${articles.length} articles.`);
+} else {
+  console.log(`✅ Migration complete.`);
+  console.log(`   Source documents created : ${totalCreated}`);
+  console.log(`   Articles patched         : ${totalPatched}`);
+}
+console.log(`══════════════════════════════════════════\n`);

--- a/src/app/(user)/articles/[slug]/page.tsx
+++ b/src/app/(user)/articles/[slug]/page.tsx
@@ -24,6 +24,7 @@ import { buildArticleMetadata } from '@/util/metadata';
 import { NewsArticleStructuredData } from '@/components/seo/NewsArticleStructuredData';
 import { getReadingTime } from '@/lib/readingTime';
 import { CorrectionNotice } from '@/components/post/CorrectionNotice';
+import { SourcesPanel } from '@/components/post/SourcesPanel';
 
 // import Comments from '@/c/post/Comments';
 
@@ -239,33 +240,10 @@ export default async function Article({ params }: Props) {
             <PortableText value={article.body} components={RichTextComponents} />
           </div>
 
-          {/* Sources */}
-          {article.sources && article.sources.length > 0 && (
-            <div className='not-prose mt-8 rounded-xl border border-slate-200 bg-white/50 p-6 dark:border-slate-700 dark:bg-slate-900/50'>
-              <h3 className='mb-3 text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-400'>
-                Sources
-              </h3>
-              <ul className='space-y-1'>
-                {article.sources.map((source, i) => (
-                  <li key={i} className='flex items-start gap-2 text-sm'>
-                    <span className='mt-0.5 text-untele'>↗</span>
-                    {source.url ? (
-                      <a
-                        href={source.url}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        className='text-slate-700 underline hover:text-untele dark:text-slate-300'
-                      >
-                        {source.label || source.url}
-                      </a>
-                    ) : (
-                      <span className='text-slate-700 dark:text-slate-300'>{source.label}</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          {/* Sources & Methodology */}
+          <div className='not-prose'>
+            <SourcesPanel sources={article.sources} methodology={article.methodology} />
+          </div>
 
           {/* FAQs */}
           {article.faqs && article.faqs.length > 0 && (

--- a/src/app/(user)/live-event/[slug]/page.tsx
+++ b/src/app/(user)/live-event/[slug]/page.tsx
@@ -8,6 +8,7 @@ import SocialShare from '@/components/global/SocialShare';
 
 import urlForImage from '@/u/urlForImage';
 import EventMap from '@/components/post/EventMap';
+import { SourcesPanel } from '@/components/post/SourcesPanel';
 
 import ClientSideRoute from '@/components/providers/ClientSideRoute';
 import formatDate from '@/util/formatDate';
@@ -241,6 +242,7 @@ export default async function LiveEvent({ params }: Props) {
           {/* Developments / Story */}
           <div className='mx-auto h-min rounded-lg border border-untele bg-slate-700/30 px-10 py-5 md:max-w-[70vw] lg:w-2/5'>
             <PortableText value={liveEvent.body} components={RichTextComponents} />
+            <SourcesPanel sources={liveEvent.sources} methodology={liveEvent.methodology} />
           </div>
         </section>
       </article>

--- a/src/components/post/SourcesPanel.tsx
+++ b/src/components/post/SourcesPanel.tsx
@@ -1,0 +1,141 @@
+// src/components/post/SourcesPanel.tsx
+// SSR-safe collapsible sources & methodology panel.
+// Uses native <details>/<summary> — works without JavaScript.
+import {
+  FileText,
+  Mic,
+  MessageSquare,
+  Database,
+  Video,
+  Eye,
+  HelpCircle,
+  Shield,
+  ExternalLink,
+} from 'lucide-react';
+
+const SOURCE_CONFIG: Record<
+  string,
+  { label: string; Icon: React.ElementType }
+> = {
+  document: { label: 'Document', Icon: FileText },
+  interview: { label: 'Interview', Icon: Mic },
+  statement: { label: 'Statement', Icon: MessageSquare },
+  data: { label: 'Data', Icon: Database },
+  media: { label: 'Video / Audio', Icon: Video },
+  onscene: { label: 'On-Scene', Icon: Eye },
+  other: { label: 'Source', Icon: HelpCircle },
+};
+
+interface SourcesPanelProps {
+  sources?: ArticleSource[];
+  methodology?: string;
+}
+
+export function SourcesPanel({ sources, methodology }: SourcesPanelProps) {
+  const hasSources = sources && sources.length > 0;
+  if (!hasSources && !methodology) return null;
+
+  const count = sources?.length ?? 0;
+
+  return (
+    <section
+      className='my-8 border border-slate-200 dark:border-slate-700'
+      aria-label='Sources and methodology'
+    >
+      <details>
+        <summary className='flex cursor-pointer select-none items-center justify-between bg-slate-100 px-4 py-3 text-xs font-black uppercase tracking-widest text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'>
+          <span>
+            Sources &amp; Methodology
+            {count > 0 && (
+              <span className='ml-2 font-normal normal-case tracking-normal text-slate-500 dark:text-slate-400'>
+                ({count} source{count !== 1 ? 's' : ''})
+              </span>
+            )}
+          </span>
+          <span className='text-slate-400 dark:text-slate-500' aria-hidden='true'>
+            ▾
+          </span>
+        </summary>
+
+        <div className='divide-y divide-slate-100 dark:divide-slate-800'>
+          {hasSources && (
+            <ul className='space-y-3 px-4 py-3'>
+              {sources.map((source, idx) => {
+                const config = SOURCE_CONFIG[source.type ?? 'other'] ?? SOURCE_CONFIG.other;
+                const { Icon } = config;
+
+                if (source.isAnonymous) {
+                  return (
+                    <li key={idx} className='flex items-start gap-3'>
+                      <Shield
+                        className='mt-0.5 h-4 w-4 shrink-0 text-slate-400'
+                        aria-hidden='true'
+                      />
+                      <div>
+                        <span className='text-sm font-medium text-slate-600 dark:text-slate-400'>
+                          Anonymous {config.label}
+                        </span>
+                        <p className='mt-0.5 text-xs text-slate-500 dark:text-slate-500'>
+                          Identity protected per editorial policy
+                        </p>
+                      </div>
+                    </li>
+                  );
+                }
+
+                return (
+                  <li key={idx} className='flex items-start gap-3'>
+                    <Icon
+                      className='mt-0.5 h-4 w-4 shrink-0 text-slate-400'
+                      aria-hidden='true'
+                    />
+                    <div className='min-w-0 flex-1'>
+                      <div className='flex flex-wrap items-center gap-2'>
+                        {source.url ? (
+                          <a
+                            href={source.url}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            className='inline-flex items-center gap-1 text-sm font-medium text-untele hover:underline'
+                          >
+                            {source.label}
+                            <ExternalLink className='h-3 w-3' aria-hidden='true' />
+                          </a>
+                        ) : (
+                          <span className='text-sm font-medium text-slate-800 dark:text-slate-200'>
+                            {source.label}
+                          </span>
+                        )}
+                        {source.type && (
+                          <span className='bg-slate-100 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-slate-500 dark:bg-slate-800 dark:text-slate-400'>
+                            {config.label}
+                          </span>
+                        )}
+                      </div>
+                      {source.description && (
+                        <p className='mt-0.5 text-xs leading-relaxed text-slate-500 dark:text-slate-400'>
+                          {source.description}
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {methodology && (
+            <blockquote className='mx-4 my-3 border-l-2 border-slate-300 px-4 py-3 dark:border-slate-600'>
+              <p className='mb-1 text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-400'>
+                Methodology
+              </p>
+              <p className='text-sm italic leading-relaxed text-slate-600 dark:text-slate-300'>
+                {methodology}
+              </p>
+            </blockquote>
+          )}
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/src/lib/sanity/lib/queries.ts
+++ b/src/lib/sanity/lib/queries.ts
@@ -98,7 +98,12 @@ export const queryEventBySlug = groq`
     *[_type == "liveEvent" && slug.current == $slug][0] {
       ...,
       eventTag[]->,
-      keyEvent[]->,
+      keyEvent[]-> {
+        ...,
+        sources[]-> { label, type, url, description, isAnonymous },
+      },
+      sources[]-> { label, type, url, description, isAnonymous },
+      methodology,
       "correction": correction { type, issuedAt, summary, detail },
       relatedArticles[]-> {
         slug,
@@ -284,7 +289,8 @@ export const queryArticleBySlug = groq`
       reviewedBy->{ name, slug, title, image },
       seo,
       faqs,
-      sources,
+      sources[]-> { label, type, url, description, isAnonymous },
+      methodology,
       "correction": correction { type, issuedAt, summary, detail },
       updatedAt,
       leadParagraph,

--- a/src/models/schema/article.ts
+++ b/src/models/schema/article.ts
@@ -113,17 +113,17 @@ export default defineType({
       name: 'sources',
       title: 'Sources',
       type: 'array',
-      of: [
-        {
-          type: 'object',
-          fields: [
-            defineField({ name: 'label', title: 'Source Name', type: 'string' }),
-            defineField({ name: 'url', title: 'Source URL', type: 'url' }),
-          ],
-          preview: { select: { title: 'label', subtitle: 'url' } },
-        },
-      ],
-      description: 'Source links displayed at the bottom of the article',
+      of: [{ type: 'reference', to: [{ type: 'source' }] }],
+      description:
+        'Reference source documents from the Sources library. Create new sources via the Sources section in the Studio.',
+    }),
+    defineField({
+      name: 'methodology',
+      title: 'Methodology Note',
+      type: 'text',
+      rows: 4,
+      description:
+        'Optional editorial note on how this story was reported — shown in the Sources panel. E.g. "This story was reported over three weeks. Documents were obtained via FOIA request #2024-1234."',
     }),
     defineField({
       name: 'leadParagraph',

--- a/src/models/schema/index.ts
+++ b/src/models/schema/index.ts
@@ -35,6 +35,7 @@ import whistleblower from './whistleblower';
 // UI/component schemas
 import ctaButton from './buttons';
 import correctionObject from './correction';
+import source from './source';
 
 // Embed schemas
 import instagramEmbed from './instagram';
@@ -93,6 +94,9 @@ export const schemaTypes = [
   // Shared object schemas
   correctionObject,
 
+  // Credibility schemas
+  source,
+
   // Add your new schemas here, grouped accordingly
   // newContentSchema,
   // newFormSchema,
@@ -144,6 +148,9 @@ export {
 
   // Shared object schemas
   correctionObject,
+
+  // Credibility schemas
+  source,
 
   // Add your new schemas here
   // newContentSchema,

--- a/src/models/schema/keyEvent.ts
+++ b/src/models/schema/keyEvent.ts
@@ -29,6 +29,13 @@ export default defineType({
       title: 'Description',
       type: 'blockContent',
     }),
+    defineField({
+      name: 'sources',
+      title: 'Sources',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'source' }] }],
+      description: 'Reference source documents from the Sources library.',
+    }),
   ],
   preview: {
     select: {

--- a/src/models/schema/liveEvent.ts
+++ b/src/models/schema/liveEvent.ts
@@ -106,6 +106,21 @@ export default defineType({
       initialValue: 'EventScheduled',
     }),
     defineField({
+      name: 'sources',
+      title: 'Sources',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'source' }] }],
+      description: 'Reference source documents from the Sources library.',
+    }),
+    defineField({
+      name: 'methodology',
+      title: 'Methodology Note',
+      type: 'text',
+      rows: 4,
+      description:
+        'Optional note on how this live event is being covered — shown in the Sources panel.',
+    }),
+    defineField({
       name: 'correction',
       title: 'Correction',
       type: 'correctionObject',

--- a/src/models/schema/source.ts
+++ b/src/models/schema/source.ts
@@ -1,0 +1,77 @@
+// src/models/schema/source.ts
+import { defineField, defineType } from 'sanity';
+import { Link } from 'lucide-react';
+
+export default defineType({
+  name: 'source',
+  title: 'Source',
+  type: 'document',
+  icon: Link,
+  description:
+    'A reusable source record. Articles, live events, and key events can all reference sources from this library.',
+  fields: [
+    defineField({
+      name: 'label',
+      title: 'Source Label',
+      type: 'string',
+      description:
+        'E.g. "Court Filing — Fulton County Superior Court", "Interview with city official"',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'type',
+      title: 'Source Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Document / Filing', value: 'document' },
+          { title: 'Interview', value: 'interview' },
+          { title: 'Official Statement', value: 'statement' },
+          { title: 'Data / Dataset', value: 'data' },
+          { title: 'Video / Audio', value: 'media' },
+          { title: 'On-Scene Reporting', value: 'onscene' },
+          { title: 'Other', value: 'other' },
+        ],
+        layout: 'dropdown',
+      },
+    }),
+    defineField({
+      name: 'url',
+      title: 'URL (optional)',
+      type: 'url',
+      description:
+        'Link to the primary source document, recording, or statement if publicly available.',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Note',
+      type: 'text',
+      rows: 2,
+      description: 'Additional context about this source. Not shown to readers if anonymous.',
+    }),
+    defineField({
+      name: 'isAnonymous',
+      title: 'Anonymous Source',
+      type: 'boolean',
+      initialValue: false,
+      description:
+        'If true, the label and note are hidden from readers — only the source type is shown.',
+    }),
+  ],
+
+  preview: {
+    select: {
+      title: 'label',
+      subtitle: 'type',
+      isAnonymous: 'isAnonymous',
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    prepare(selection: any) {
+      const { title, subtitle, isAnonymous } = selection;
+      return {
+        title: isAnonymous ? '🔒 Anonymous Source' : title,
+        subtitle: subtitle ?? 'No type set',
+      };
+    },
+  },
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,6 +6,16 @@ type Base = {
   _updatedAt: string;
 };
 
+type SourceType = 'document' | 'interview' | 'statement' | 'data' | 'media' | 'onscene' | 'other';
+
+interface ArticleSource {
+  label: string;
+  type?: SourceType;
+  url?: string;
+  description?: string;
+  isAnonymous?: boolean;
+}
+
 interface ArticleCorrection {
   type: 'correction' | 'clarification' | 'update' | 'retraction';
   issuedAt?: string;
@@ -39,6 +49,8 @@ interface LiveEvent extends Base {
   isCurrentEvent: boolean;
   mainImage: Image;
   correction?: ArticleCorrection;
+  sources?: ArticleSource[];
+  methodology?: string;
   seo?: SeoOverride;
 }
 
@@ -47,6 +59,7 @@ interface KeyEvent extends Base {
   slug: Slug;
   eventDate: string;
   description: Block[];
+  sources?: ArticleSource[];
 }
 
 interface Article extends Base {
@@ -68,7 +81,8 @@ interface Article extends Base {
   updatedAt?: string;
   leadParagraph?: string;
   correction?: ArticleCorrection;
-  sources?: Array<{ label: string; url: string }>;
+  sources?: ArticleSource[];
+  methodology?: string;
   faqs?: Array<{ question: string; answer: string }>;
   reviewedBy?: Author;
   relatedArticles?: Array<{


### PR DESCRIPTION
## Summary

Closes #24

Implements the full Source Transparency Panel as described in the issue, with one architectural change per the issue comment: **`source` is a standalone Sanity document** (not an inline object) so it can be reused across articles, live events, and key events.

- New `source` document type with label, type, url, description, and `isAnonymous` flag — editors build a source library and reference from any content type
- `article`: `sources[]` now references `source` documents; `methodology` text field added
- `liveEvent`: `sources[]` references + `methodology` added
- `keyEvent`: `sources[]` references added (per issue comment)
- `SourcesPanel` component: SSR-safe `<details>`/`<summary>`, no JS dependency, per-type icons, anonymous source protection, methodology blockquote
- `articles/[slug]`: replaces old minimal sources list with `SourcesPanel`
- `live-event/[slug]`: `SourcesPanel` added after body content

## Files Changed

| File | Change |
|---|---|
| `src/models/schema/source.ts` | **New** — standalone source document |
| `src/models/schema/article.ts` | Replace inline sources array → references; add methodology |
| `src/models/schema/liveEvent.ts` | Add sources references + methodology |
| `src/models/schema/keyEvent.ts` | Add sources references |
| `src/models/schema/index.ts` | Register source schema |
| `src/lib/sanity/lib/queries.ts` | Update projections for article + live event queries |
| `types.d.ts` | Add `ArticleSource`, `SourceType`; update Article/LiveEvent/KeyEvent |
| `src/components/post/SourcesPanel.tsx` | **New** — collapsible panel component |
| `src/app/(user)/articles/[slug]/page.tsx` | Replace old sources with SourcesPanel |
| `src/app/(user)/live-event/[slug]/page.tsx` | Add SourcesPanel after body |

## Test plan

- [ ] Create a `source` document in Studio — verify all fields render, anonymous preview shows 🔒
- [ ] Attach sources to an article, open article page — panel visible and collapsed by default
- [ ] Test with anonymous source — label/description hidden, Shield icon shown
- [ ] Test with linked source — opens new tab, ExternalLink icon shown
- [ ] Test methodology only (no sources) — panel renders with just methodology
- [ ] Test no sources + no methodology — panel does not render
- [ ] Attach sources to a live event — panel visible on event page
- [ ] Attach sources to a key event — saved correctly in Studio
- [ ] Dark mode verified on article page
- [ ] TypeScript: `pnpm tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)