### PR TITLE
feat(tags): Tag Pages — /tag/[slug] route with Sanity schema and sitemap (#8)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npx lint-staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **Tag Pages (#8)**
+  - `tags` string-array field added to the `article` Sanity schema (max 10, tag-input layout); values become browsable `/tag/[slug]` pages
+
 ---
 
 ## [2.3.0] — 2026-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- **Tag Pages (#8)**
-  - `tags` string-array field added to the `article` Sanity schema (max 10, tag-input layout); values become browsable `/tag/[slug]` pages
+- **Tag Pages (#8, PR #N)**
+
+  **Sanity schema**
+  - `tags` string-array field on the `article` document type (max 10, tag-input layout in Studio); values are fine-grained topics, people, places, or events using lowercase-hyphen convention
+
+  **Utilities (`src/lib/tagUtils.ts`)**
+  - `tagToSlug(tag)` — normalises raw tag string to a URL-safe slug
+  - `slugToTagLabel(slug)` — converts slug back to title-case display label
+  - `tagPageUrl(tag)` — convenience helper returning the `/tag/[slug]` path
+
+  **GROQ queries (`src/lib/sanity/lib/queries.ts`)**
+  - `queryAllTags` — returns a deduplicated flat array of every tag in use across published articles
+  - `queryArticlesByTag` — fetches articles containing a given raw tag string, ordered by `publishedAt desc`
+  - `queryAllArticles` updated to include `tags` in its projection
+
+  **Tag page route (`src/app/(user)/tag/[slug]/page.tsx`)**
+  - `generateStaticParams` fetches all tags via `sanityClient` and maps to `{ slug: tagToSlug(tag) }` params
+  - `generateMetadata` returns a canonical URL at `https://www.untelevised.media/tag/[slug]`
+  - CollectionPage JSON-LD structured data
+  - Breadcrumb nav: Home > Tags > [Label]
+  - `bg-untele` header bar with "TAG" pill, article count, and tag description line
+  - Article grid using `ArticleCardLg` — consistent with category pages
+  - Empty state rendered when no articles match
+
+  **Article detail page (`src/app/(user)/articles/[slug]/page.tsx`)**
+  - Tag badges rendered below Sources panel; each links to the corresponding `/tag/[slug]` page
+  - Section labelled "Filed Under" using brand label typography
+  - Section hidden when `article.tags` is empty or undefined
+
+  **Sitemap (`src/app/(user)/sitemap.ts`)**
+  - All tag pages added with `changeFrequency: 'daily'` and `priority: 0.5`
+
+  **Types (`types.d.ts`)**
+  - `tags?: string[]` added to the global `Article` interface
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Tag badges rendered below Sources panel; each links to the corresponding `/tag/[slug]` page
   - Section labelled "Filed Under" using brand label typography
   - Section hidden when `article.tags` is empty or undefined
+  - Tags and categories now displayed together in the article hero header with distinct visual styles — categories as solid `bg-untele` red pills (linked to `/category/[slug]`), tags as ghost outline pills with `#` prefix (linked to `/tag/[slug]`)
+  - Article breadcrumb fixed to use `formatTitleForURL(category.title)` for category href — was using `slug.current` which caused 404s; also now links correctly to `/category/[slug]`
+  - BreadcrumbList JSON-LD updated with correct category URL and 3-item trail (Home → Category → Article)
 
   **Sitemap (`src/app/(user)/sitemap.ts`)**
   - All tag pages added with `changeFrequency: 'daily'` and `priority: 0.5`
 
   **Types (`types.d.ts`)**
   - `tags?: string[]` added to the global `Article` interface
+
+- **Instagram embed hydration fix**
+  - Extracted Instagram blockquote markup into `InstagramEmbedInner.tsx` (client component, never SSR'd)
+  - `InstagramEmbed.tsx` wraps it via `dynamic(..., { ssr: false })` — eliminates React hydration mismatch caused by Instagram's `embed.js` rewriting `<blockquote>` → `<iframe>` before hydration completes
 
 ---
 

--- a/src/app/(user)/articles/[slug]/page.tsx
+++ b/src/app/(user)/articles/[slug]/page.tsx
@@ -67,6 +67,37 @@ export default async function Article({ params }: Props) {
   return (
     <div className='min-h-screen bg-gradient-to-br from-slate-50 via-slate-100 to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950'>
       <NewsArticleStructuredData article={article} slug={slug} />
+
+      {/* BreadcrumbList JSON-LD */}
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              {
+                '@type': 'ListItem',
+                position: 1,
+                name: 'Home',
+                item: 'https://www.untelevised.media',
+              },
+              ...(article.categories?.slice(0, 1).map((cat) => ({
+                '@type': 'ListItem',
+                position: 2,
+                name: cat.title,
+                item: `https://www.untelevised.media/category/${cat.slug?.current}`,
+              })) ?? []),
+              {
+                '@type': 'ListItem',
+                position: (article.categories?.length ? 3 : 2),
+                name: article.title,
+                item: `https://www.untelevised.media/articles/${slug}`,
+              },
+            ],
+          }),
+        }}
+      />
       {/* Hero Section */}
       <section className='relative overflow-hidden'>
         {/* Background Image with Overlay */}
@@ -185,6 +216,40 @@ export default async function Article({ params }: Props) {
 
       {/* Main Content */}
       <main className='mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8'>
+        {/* Breadcrumb */}
+        <nav
+          aria-label='Breadcrumb'
+          className='mb-8 text-xs font-medium uppercase tracking-widest text-slate-500 dark:text-slate-400'
+        >
+          <ol className='flex flex-wrap items-center gap-2'>
+            <li>
+              <Link href='/' className='transition-colors hover:text-untele'>
+                Home
+              </Link>
+            </li>
+            {article.categories && article.categories.length > 0 && (
+              <>
+                <li aria-hidden='true' className='text-slate-400 dark:text-slate-600'>/</li>
+                <li>
+                  <Link
+                    href={`/category/${article.categories[0].slug?.current}`}
+                    className='transition-colors hover:text-untele'
+                  >
+                    {article.categories[0].title}
+                  </Link>
+                </li>
+              </>
+            )}
+            <li aria-hidden='true' className='text-slate-400 dark:text-slate-600'>/</li>
+            <li
+              className='max-w-xs truncate text-slate-900 dark:text-white'
+              aria-current='page'
+            >
+              {article.title}
+            </li>
+          </ol>
+        </nav>
+
         {/* Social Share + Bookmark */}
         <div className='mb-8 flex flex-col items-center gap-3 sm:flex-row sm:items-start sm:justify-between'>
           <SocialShare url={`https://untelevised.media/articles/${slug}`} title={article.title} />

--- a/src/app/(user)/articles/[slug]/page.tsx
+++ b/src/app/(user)/articles/[slug]/page.tsx
@@ -15,6 +15,7 @@ import ClientSideRoute from '@/components/providers/ClientSideRoute';
 import formatDate from '@/util/formatDate';
 import getArticleDate from '@/util/getArticleDate';
 import resolveHref from '@/util/resolveHref';
+import { tagToSlug } from '@/lib/tagUtils';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { sanityFetch } from '@/lib/sanity/lib/live';
@@ -256,6 +257,26 @@ export default async function Article({ params }: Props) {
           <div className='not-prose'>
             <SourcesPanel sources={article.sources} methodology={article.methodology} />
           </div>
+
+          {/* Tags */}
+          {article.tags && article.tags.length > 0 && (
+            <div className='not-prose mt-8'>
+              <p className='mb-3 text-xs font-black uppercase tracking-widest text-muted-foreground'>
+                Filed Under
+              </p>
+              <div className='flex flex-wrap gap-2'>
+                {article.tags.map((tag: string) => (
+                  <Link
+                    key={tag}
+                    href={`/tag/${tagToSlug(tag)}`}
+                    className='border border-zinc-600 px-3 py-1 text-xs uppercase tracking-wide text-zinc-400 transition-colors hover:border-untele hover:text-white'
+                  >
+                    {tag}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* FAQs */}
           {article.faqs && article.faqs.length > 0 && (

--- a/src/app/(user)/articles/[slug]/page.tsx
+++ b/src/app/(user)/articles/[slug]/page.tsx
@@ -16,6 +16,7 @@ import formatDate from '@/util/formatDate';
 import getArticleDate from '@/util/getArticleDate';
 import resolveHref from '@/util/resolveHref';
 import { tagToSlug } from '@/lib/tagUtils';
+import formatTitleForURL from '@/util/formatTitleForURL';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { sanityFetch } from '@/lib/sanity/lib/live';
@@ -86,11 +87,11 @@ export default async function Article({ params }: Props) {
                 '@type': 'ListItem',
                 position: 2,
                 name: cat.title,
-                item: `https://www.untelevised.media/category/${cat.slug?.current}`,
+                item: `https://www.untelevised.media/category/${formatTitleForURL(cat.title)}`,
               })) ?? []),
               {
                 '@type': 'ListItem',
-                position: (article.categories?.length ? 3 : 2),
+                position: article.categories?.length ? 3 : 2,
                 name: article.title,
                 item: `https://www.untelevised.media/articles/${slug}`,
               },
@@ -194,19 +195,29 @@ export default async function Article({ params }: Props) {
                       </span>
                     )}
                   </div>
-                  {/* Categories */}
-                  {article.categories && article.categories.length > 0 && (
-                    <div className='flex flex-wrap justify-end gap-2'>
-                      {article.categories.map((category) => (
-                        <span
+                  {/* Categories + Tags */}
+                  <div className='flex flex-wrap justify-end gap-2'>
+                    {article.categories && article.categories.length > 0 &&
+                      article.categories.map((category) => (
+                        <Link
                           key={category._id}
-                          className='inline-flex items-center rounded-full bg-untele/90 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm'
+                          href={`/category/${formatTitleForURL(category.title)}`}
+                          className='inline-flex items-center rounded-full bg-untele/90 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm transition-colors hover:bg-untele'
                         >
                           {category.title}
-                        </span>
+                        </Link>
                       ))}
-                    </div>
-                  )}
+                    {article.tags && article.tags.length > 0 &&
+                      article.tags.map((tag) => (
+                        <Link
+                          key={tag}
+                          href={`/tag/${tagToSlug(tag)}`}
+                          className='inline-flex items-center rounded-full border border-white/40 bg-white/10 px-3 py-1 text-xs font-medium text-white/80 backdrop-blur-sm transition-colors hover:border-white/70 hover:text-white'
+                        >
+                          #{tag}
+                        </Link>
+                      ))}
+                  </div>
                 </div>
               </div>
             </div>
@@ -232,7 +243,7 @@ export default async function Article({ params }: Props) {
                 <li aria-hidden='true' className='text-slate-400 dark:text-slate-600'>/</li>
                 <li>
                   <Link
-                    href={`/category/${article.categories[0].slug?.current}`}
+                    href={`/category/${formatTitleForURL(article.categories[0].title)}`}
                     className='transition-colors hover:text-untele'
                   >
                     {article.categories[0].title}

--- a/src/app/(user)/sitemap.ts
+++ b/src/app/(user)/sitemap.ts
@@ -3,6 +3,8 @@
 import getAllURLs from '@/util/getAllUrls';
 import sanityClient from '@/lib/sanity/lib/client';
 import { groq } from 'next-sanity';
+import { queryAllTags } from '@/lib/sanity/lib/queries';
+import { tagToSlug } from '@/lib/tagUtils';
 
 const queryFactCheckSlugs = groq`
   *[_type == 'factCheck'] {
@@ -22,10 +24,10 @@ export default async function sitemap(): Promise<
   }[]
 > {
   const allNews = await getAllURLs();
-  const factCheckDocs =
-    await sanityClient.fetch<{ slug: { current: string }; _updatedAt: string }[]>(
-      queryFactCheckSlugs
-    );
+  const [factCheckDocs, allTags] = await Promise.all([
+    sanityClient.fetch<{ slug: { current: string }; _updatedAt: string }[]>(queryFactCheckSlugs),
+    sanityClient.fetch<string[]>(queryAllTags),
+  ]);
 
   const now = new Date();
   const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -123,6 +125,13 @@ export default async function sitemap(): Promise<
     priority: 0.7,
   }));
 
+  const tagURLs = (allTags ?? []).map((tag) => ({
+    url: `https://www.untelevised.media/tag/${tagToSlug(tag)}`,
+    lastModified: now,
+    changeFrequency: 'daily' as const,
+    priority: 0.5,
+  }));
+
   return [
     // Homepage — highest priority
     {
@@ -142,6 +151,7 @@ export default async function sitemap(): Promise<
     ...albumURLs,
     ...timelineURLs,
     ...factCheckURLs,
+    ...tagURLs,
     // Static section pages — music
     {
       url: 'https://www.untelevised.media/lyrics/',

--- a/src/app/(user)/tag/[slug]/page.tsx
+++ b/src/app/(user)/tag/[slug]/page.tsx
@@ -1,0 +1,143 @@
+/* eslint-disable react/function-component-definition */
+// src/app/(user)/tag/[slug]/page.tsx
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import ArticleCardLg from '@/components/cards/ArticleCardLg';
+import ClientSideRoute from '@/components/providers/ClientSideRoute';
+import resolveHref from '@/util/resolveHref';
+import { sanityFetch } from '@/lib/sanity/lib/live';
+import sanityClient from '@/lib/sanity/lib/client';
+import { queryAllTags, queryArticlesByTag } from '@/lib/sanity/lib/queries';
+import { tagToSlug, slugToTagLabel } from '@/lib/tagUtils';
+
+type Props = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const label = slugToTagLabel(slug);
+  return {
+    title: `${label} | UnTelevised Media`,
+    description: `Browse all UnTelevised Media articles filed under the tag "${label}".`,
+    alternates: {
+      canonical: `https://www.untelevised.media/tag/${slug}`,
+    },
+  };
+}
+
+export default async function TagPage({ params }: Props) {
+  const { slug } = await params;
+
+  // Fetch all known tags to find the canonical raw tag string
+  const { data: allTags } = await sanityFetch<string[]>({
+    query: queryAllTags,
+    tags: ['article'],
+  });
+
+  const matchedTag = (allTags ?? []).find((tag: string) => tagToSlug(tag) === slug);
+
+  if (!matchedTag) notFound();
+
+  const { data: articles } = await sanityFetch({
+    query: queryArticlesByTag,
+    params: { tag: matchedTag },
+    tags: ['article'],
+  });
+
+  const label = slugToTagLabel(slug);
+  const articleCount = articles?.length ?? 0;
+
+  const collectionPageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `${label} — UnTelevised Media`,
+    description: `Browse all articles tagged "${label}" on UnTelevised Media.`,
+    url: `https://www.untelevised.media/tag/${slug}`,
+    publisher: {
+      '@type': 'NewsMediaOrganization',
+      '@id': 'https://www.untelevised.media/#organization',
+      name: 'UnTelevised Media',
+    },
+  };
+
+  return (
+    <div className='mx-auto max-w-[95vw] md:max-w-[85vw]'>
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionPageSchema) }}
+      />
+
+      <hr className='mb-8 border-untele' />
+
+      {/* Breadcrumb */}
+      <nav
+        aria-label='Breadcrumb'
+        className='mb-6 px-10 text-xs font-medium uppercase tracking-widest text-muted-foreground'
+      >
+        <ol className='flex items-center gap-2'>
+          <li>
+            <Link href='/' className='hover:text-untele transition-colors'>
+              Home
+            </Link>
+          </li>
+          <li aria-hidden='true'>/</li>
+          <li>
+            <span className='text-slate-500'>Tags</span>
+          </li>
+          <li aria-hidden='true'>/</li>
+          <li className='text-slate-900 dark:text-white'>{label}</li>
+        </ol>
+      </nav>
+
+      {/* Header bar */}
+      <div className='mb-10 px-10'>
+        <div className='mb-4 inline-flex items-center gap-3'>
+          <span className='bg-untele px-2 py-0.5 text-[10px] font-black uppercase tracking-widest text-white'>
+            TAG
+          </span>
+          <h1 className='text-3xl font-black uppercase tracking-widest text-slate-900 dark:text-white'>
+            {label}
+          </h1>
+          <span className='text-sm font-medium text-slate-500 dark:text-slate-400'>
+            {articleCount} {articleCount === 1 ? 'article' : 'articles'}
+          </span>
+        </div>
+        <p className='max-w-2xl text-slate-600 dark:text-slate-400'>
+          Browse all stories filed under{' '}
+          <span className='font-semibold text-slate-800 dark:text-slate-200'>{label}</span>.
+        </p>
+      </div>
+
+      {/* Articles grid */}
+      {articleCount > 0 ? (
+        <div className='grid grid-cols-1 gap-x-10 gap-y-12 px-10 pb-24 md:grid-cols-2 xl:grid-cols-3'>
+          {articles.map((article: Article) => (
+            <ClientSideRoute
+              route={resolveHref('article', article.slug?.current) ?? ''}
+              key={article._id}
+            >
+              <ArticleCardLg post={article} />
+            </ClientSideRoute>
+          ))}
+        </div>
+      ) : (
+        <div className='px-10 pb-24'>
+          <p className='text-slate-500 dark:text-slate-400'>
+            No articles found for this tag yet.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export async function generateStaticParams() {
+  const tags: string[] = await sanityClient.fetch(queryAllTags);
+  if (!tags || tags.length === 0) return [];
+  return tags.map((tag) => ({ slug: tagToSlug(tag) }));
+}

--- a/src/app/(user)/tag/[slug]/page.tsx
+++ b/src/app/(user)/tag/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function TagPage({ params }: Props) {
   const { slug } = await params;
 
   // Fetch all known tags to find the canonical raw tag string
-  const { data: allTags } = await sanityFetch<string[]>({
+  const { data: allTags } = await sanityFetch({
     query: queryAllTags,
     tags: ['article'],
   });

--- a/src/components/cards/ArticleCardLg.tsx
+++ b/src/components/cards/ArticleCardLg.tsx
@@ -18,7 +18,7 @@ const ArticleCardLg = ({ post }: Props) => {
 
   return (
     <article
-      className='group relative flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:border-untele hover:shadow-lg dark:border-slate-800 dark:bg-slate-900 dark:hover:border-untele'
+      className='group relative flex flex-col overflow-hidden border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:border-untele hover:shadow-lg dark:border-slate-800 dark:bg-slate-900 dark:hover:border-untele'
       aria-labelledby={`article-title-${post._id}`}
     >
       {/* Image */}

--- a/src/components/cards/ArticleCardLg.tsx
+++ b/src/components/cards/ArticleCardLg.tsx
@@ -18,7 +18,7 @@ const ArticleCardLg = ({ post }: Props) => {
 
   return (
     <article
-      className='group relative flex flex-col overflow-hidden rounded-lg border border-slate-400 bg-slate-400/80 shadow-lg transition-all duration-300 hover:border-untele/50 hover:shadow-xl'
+      className='group relative flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:border-untele hover:shadow-lg dark:border-slate-800 dark:bg-slate-900 dark:hover:border-untele'
       aria-labelledby={`article-title-${post._id}`}
     >
       {/* Image */}
@@ -32,13 +32,13 @@ const ArticleCardLg = ({ post }: Props) => {
             sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
           />
         ) : (
-          <div className='h-full w-full bg-slate-700' />
+          <div className='h-full w-full bg-slate-200 dark:bg-slate-800' />
         )}
-        <div className='absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent' />
+        <div className='absolute inset-0 bg-gradient-to-t from-black/50 to-transparent' />
       </div>
 
       {/* Content */}
-      <div className='flex flex-1 flex-col bg-slate-400 p-6'>
+      <div className='flex flex-1 flex-col p-6'>
         {/* Category pills */}
         {post.categories && post.categories.length > 0 && (
           <div className='mb-4 flex flex-wrap gap-2'>
@@ -69,25 +69,25 @@ const ArticleCardLg = ({ post }: Props) => {
         {/* Title */}
         <h2
           id={`article-title-${post._id}`}
-          className={`mb-2 text-xl font-bold text-slate-900 transition-colors group-hover:text-untele${post.correction?.type === 'retraction' ? ' line-through opacity-60' : ''}`}
+          className={`mb-2 text-xl font-bold text-slate-900 transition-colors group-hover:text-untele dark:text-white${post.correction?.type === 'retraction' ? ' line-through opacity-60' : ''}`}
         >
           {post.title}
         </h2>
 
         {/* Description */}
-        <p className='mb-4 line-clamp-4 flex-grow text-sm text-slate-700'>
+        <p className='mb-4 line-clamp-4 flex-grow text-sm text-slate-600 dark:text-slate-400'>
           {post.description}
         </p>
 
         {/* Meta row */}
         <div className='mt-auto flex items-center justify-between'>
-          <span className='text-sm text-slate-600'>{post.author?.name}</span>
+          <span className='text-sm text-slate-500 dark:text-slate-400'>{post.author?.name}</span>
           <div className='flex items-center gap-2'>
-            <span className='text-sm text-slate-600'>
+            <span className='text-sm text-slate-500 dark:text-slate-400'>
               {formatDate(getArticleDate(post))}
             </span>
             {post.body && (
-              <span className='text-xs uppercase tracking-widest text-slate-500'>
+              <span className='text-xs uppercase tracking-widest text-slate-400 dark:text-slate-500'>
                 · {getReadingTime(post.body)}
               </span>
             )}

--- a/src/components/cards/ArticleCardLg.tsx
+++ b/src/components/cards/ArticleCardLg.tsx
@@ -1,72 +1,101 @@
+// src/components/cards/ArticleCardLg.tsx
+// Single-article card used in category and tag grid pages.
+// Wrapped externally by ClientSideRoute (Link) — no internal Link element.
 import Image from 'next/image';
-import urlForImage from '@/u/urlForImage';
-import { ArrowUpRightIcon, ShareIcon } from '@heroicons/react/24/solid';
-import { AlertTriangle, XCircle } from 'lucide-react';
+import { ArrowUpRight, AlertTriangle, XCircle } from 'lucide-react';
+
 import formatDate from '@/util/formatDate';
 import getArticleDate from '@/util/getArticleDate';
+import urlForImage from '@/util/urlForImage';
+import { getReadingTime } from '@/lib/readingTime';
 
 type Props = {
   post: Article;
 };
 
 const ArticleCardLg = ({ post }: Props) => {
+  const imageUrl = urlForImage(post.mainImage as any)?.url();
+
   return (
-    <div className='group flex cursor-pointer flex-col rounded-lg border border-slate-400 pb-4 shadow-lg drop-shadow-sm'>
-      <div className='relative h-80 w-full drop-shadow-xl transition-transform duration-200 ease-out group-hover:scale-105'>
-        <Image
-          className='rounded-md object-cover object-left lg:object-center'
-          src={
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            urlForImage(post.mainImage as any)?.url() ?? ''
-          }
-          fill
-          alt={post.mainImage?.alt ?? 'No Alt Tag Set'}
-        />
-        <div className='absolute bottom-0 flex w-full justify-between rounded bg-slate-900 bg-opacity-20 px-5 py-2 text-slate-200 drop-shadow-lg backdrop-blur-lg'>
-          <div>
-            {post.correction?.type === 'retraction' ? (
-              <span className='mb-1 inline-flex items-center gap-1 bg-untele px-1.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-white'>
-                <XCircle className='h-2.5 w-2.5' aria-hidden='true' />
-                Retracted
-              </span>
-            ) : post.correction?.summary ? (
-              <span className='mb-1 inline-flex items-center gap-1 bg-amber-400 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-black'>
-                <AlertTriangle className='h-2.5 w-2.5' aria-hidden='true' />
-                Corrected
-              </span>
-            ) : null}
-            <p className={`text-sm font-bold lg:text-base${post.correction?.type === 'retraction' ? ' line-through opacity-60' : ''}`}>{post.title}</p>
-          </div>
-          <div className='flex flex-col items-center gap-y-2 md:flex-row md:gap-x-2'>
-            {
-              post.categories && post.categories.length > 0 // Check if categories exist and are not empty
-                ? post.categories.map((category) => (
-                    <div
-                      key={category._id}
-                      className='hidden rounded-xl border border-slate-900 bg-untele/70 px-5 py-2 text-center text-xs font-light text-slate-900 md:flex lg:text-sm'
-                    >
-                      <p>{category.title}</p>
-                    </div>
-                  ))
-                : null // Display nothing if no category for article
-            }
-          </div>
-        </div>
+    <article
+      className='group relative flex flex-col overflow-hidden rounded-lg border border-slate-400 bg-slate-400/80 shadow-lg transition-all duration-300 hover:border-untele/50 hover:shadow-xl'
+      aria-labelledby={`article-title-${post._id}`}
+    >
+      {/* Image */}
+      <div className='relative aspect-video overflow-hidden'>
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={post.mainImage?.alt ?? post.title}
+            fill
+            className='object-cover transition-transform duration-300 group-hover:scale-105'
+            sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+          />
+        ) : (
+          <div className='h-full w-full bg-slate-700' />
+        )}
+        <div className='absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent' />
       </div>
-      <div className='mt-0 flex-1 bg-slate-400'>
-        <div className='flex space-x-4 p-1'>
-          <h4 className='text-sm font-semibold md:text-base'>By: {post.author.name}</h4>
-          <h4 className='text-sm font-light md:text-base'>{formatDate(getArticleDate(post))}</h4>
-        </div>
-        <p className='line-clamp-3 px-4 pb-1 pt-2'>{post.description}</p>
-      </div>
-      <div className='flex justify-between drop-shadow-sm'>
-        <p className='ml-4 mt-3 flex items-center font-bold group-hover:underline'>
-          Read Article <ArrowUpRightIcon className='group ml-2 h-4 w-4' />
+
+      {/* Content */}
+      <div className='flex flex-1 flex-col bg-slate-400 p-6'>
+        {/* Category pills */}
+        {post.categories && post.categories.length > 0 && (
+          <div className='mb-4 flex flex-wrap gap-2'>
+            {post.categories.map((category) => (
+              <span
+                key={category._id ?? category.title}
+                className='inline-block w-fit rounded-full border border-untele/30 bg-untele/10 px-3 py-1 text-xs font-medium text-untele'
+              >
+                {category.title}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Correction badges */}
+        {post.correction?.type === 'retraction' ? (
+          <span className='mb-2 inline-flex items-center gap-1 bg-untele px-1.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-white'>
+            <XCircle className='h-2.5 w-2.5' aria-hidden='true' />
+            Retracted
+          </span>
+        ) : post.correction?.summary ? (
+          <span className='mb-2 inline-flex items-center gap-1 bg-amber-400 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-black'>
+            <AlertTriangle className='h-2.5 w-2.5' aria-hidden='true' />
+            Corrected
+          </span>
+        ) : null}
+
+        {/* Title */}
+        <h2
+          id={`article-title-${post._id}`}
+          className={`mb-2 text-xl font-bold text-slate-900 transition-colors group-hover:text-untele${post.correction?.type === 'retraction' ? ' line-through opacity-60' : ''}`}
+        >
+          {post.title}
+        </h2>
+
+        {/* Description */}
+        <p className='mb-4 line-clamp-4 flex-grow text-sm text-slate-700'>
+          {post.description}
         </p>
-        <ShareIcon className='mr-4 mt-4 h-6 w-6 transition-transform duration-200 ease-out hover:scale-110 hover:text-untele' />
+
+        {/* Meta row */}
+        <div className='mt-auto flex items-center justify-between'>
+          <span className='text-sm text-slate-600'>{post.author?.name}</span>
+          <div className='flex items-center gap-2'>
+            <span className='text-sm text-slate-600'>
+              {formatDate(getArticleDate(post))}
+            </span>
+            {post.body && (
+              <span className='text-xs uppercase tracking-widest text-slate-500'>
+                · {getReadingTime(post.body)}
+              </span>
+            )}
+            <ArrowUpRight className='h-4 w-4 text-untele transition-transform duration-300 group-hover:-translate-y-1 group-hover:translate-x-1' />
+          </div>
+        </div>
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/components/providers/InstagramEmbed.tsx
+++ b/src/components/providers/InstagramEmbed.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+// Dynamic import with ssr:false must live in a Client Component.
+// This file is the public export; the actual blockquote markup is in InstagramEmbedInner.
+import dynamic from 'next/dynamic';
+
+const InstagramEmbedInner = dynamic(() => import('./InstagramEmbedInner'), { ssr: false });
+
+export default function InstagramEmbed({ postId }: { postId: string }) {
+  return <InstagramEmbedInner postId={postId} />;
+}

--- a/src/components/providers/InstagramEmbedInner.tsx
+++ b/src/components/providers/InstagramEmbedInner.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function InstagramEmbedInner({ postId }: { postId: string }) {
+  return (
+    <div className='mx-auto my-8 flex max-w-full justify-center'>
+      <blockquote
+        className='instagram-media min-w-fit max-w-xl'
+        data-instgrm-captioned
+        data-instgrm-permalink={`https://www.instagram.com/p/${postId}`}
+        data-instgrm-version='14'
+      >
+        <div>
+          <Link
+            href={`https://www.instagram.com/p/${postId}`}
+            className='text-untele hover:text-red-700'
+            target='_blank'
+          >
+            View this post on Instagram
+          </Link>
+        </div>
+      </blockquote>
+      <script async src='//www.instagram.com/embed.js'></script>
+    </div>
+  );
+}

--- a/src/components/providers/RichTextComponents.tsx
+++ b/src/components/providers/RichTextComponents.tsx
@@ -15,6 +15,7 @@ const Tweet = dynamic(() => import('react-tweet').then((m) => m.Tweet));
 const SyntaxHighlighter = dynamic(() =>
   import('react-syntax-highlighter').then((m) => m.Prism),
 );
+import InstagramEmbed from './InstagramEmbed';
 
 export const RichTextComponents = {
   types: {
@@ -224,27 +225,7 @@ export const RichTextComponents = {
     // ── Instagram Embeds ─────────────────────────────────────────────────────
     instagramEmbed: ({ value }: any) => {
       const postId = value.postId;
-      return (
-        <div className='mx-auto my-8 flex max-w-full justify-center'>
-          <blockquote
-            className='instagram-media min-w-fit max-w-xl'
-            data-instgrm-captioned
-            data-instgrm-permalink={`https://www.instagram.com/p/${postId}`}
-            data-instgrm-version='14'
-          >
-            <div>
-              <Link
-                href={`https://www.instagram.com/p/${postId}`}
-                className='text-untele hover:text-red-700'
-                target='_blank'
-              >
-                View this post on Instagram
-              </Link>
-            </div>
-          </blockquote>
-          <script async src='//www.instagram.com/embed.js'></script>
-        </div>
-      );
+      return <InstagramEmbed postId={postId} />;
     },
   },
 

--- a/src/lib/sanity/lib/queries.ts
+++ b/src/lib/sanity/lib/queries.ts
@@ -737,9 +737,10 @@ export const queryArticlesByTag = groq`
     slug,
     description,
     publishedAt,
-    mainImage { asset->, alt },
-    "author": author->{ name, slug, image { asset-> } },
-    "categories": categories[]->{ title, slug },
+    mainImage { asset, alt },
+    "author": author->{ name, slug, image { asset } },
+    "categories": categories[]->{ _id, title, slug },
+    "correction": correction { type, summary },
     tags
   }
 `;

--- a/src/lib/sanity/lib/queries.ts
+++ b/src/lib/sanity/lib/queries.ts
@@ -727,7 +727,7 @@ export const queryFactCheckBySlug = groq`
 // ── Tag Queries ──────────────────────────────────────────────────────────────
 
 export const queryAllTags = groq`
-  array::unique(*[_type == "article" && defined(tags) && array::length(tags) > 0].tags[])
+  array::unique(*[_type == "article" && defined(tags) && count(tags) > 0].tags[])
 `;
 
 export const queryArticlesByTag = groq`

--- a/src/lib/sanity/lib/queries.ts
+++ b/src/lib/sanity/lib/queries.ts
@@ -123,6 +123,7 @@ export const queryAllArticles = groq`
     categories[]->,
     description,
     publishedAt,
+    tags,
     "correction": correction { type, summary },
   }
   | order(_createdAt desc)
@@ -720,5 +721,25 @@ export const queryFactCheckBySlug = groq`
     relatedArticles[]-> {
       _id, title, slug, mainImage, publishedAt, description
     }
+  }
+`;
+
+// ── Tag Queries ──────────────────────────────────────────────────────────────
+
+export const queryAllTags = groq`
+  array::unique(*[_type == "article" && defined(tags) && array::length(tags) > 0].tags[])
+`;
+
+export const queryArticlesByTag = groq`
+  *[_type == "article" && defined(tags) && $tag in tags[]] | order(publishedAt desc) {
+    _id,
+    title,
+    slug,
+    description,
+    publishedAt,
+    mainImage { asset->, alt },
+    "author": author->{ name, slug, image { asset-> } },
+    "categories": categories[]->{ title, slug },
+    tags
   }
 `;

--- a/src/lib/tagUtils.ts
+++ b/src/lib/tagUtils.ts
@@ -1,0 +1,19 @@
+// src/lib/tagUtils.ts
+
+export function tagToSlug(tag: string): string {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function slugToTagLabel(slug: string): string {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function tagPageUrl(tag: string): string {
+  return `/tag/${tagToSlug(tag)}`;
+}

--- a/src/models/schema/article.ts
+++ b/src/models/schema/article.ts
@@ -73,6 +73,16 @@ export default defineType({
       of: [{ type: 'reference', to: { type: 'category' } }],
     }),
     defineField({
+      name: 'tags',
+      title: 'Tags',
+      type: 'array',
+      of: [{ type: 'string' }],
+      options: { layout: 'tags' },
+      description:
+        'Fine-grained topics, people, places, or events. Use lowercase with hyphens (e.g. "police-brutality", "eric-adams"). These become browsable /tag/[slug] pages.',
+      validation: (Rule) => Rule.max(10).warning('Keep tags focused — 10 max per article.'),
+    }),
+    defineField({
       name: 'publishedAt',
       title: 'Published at',
       type: 'datetime',

--- a/types.d.ts
+++ b/types.d.ts
@@ -83,6 +83,7 @@ interface Article extends Base {
   correction?: ArticleCorrection;
   sources?: ArticleSource[];
   methodology?: string;
+  tags?: string[];
   faqs?: Array<{ question: string; answer: string }>;
   reviewedBy?: Author;
   relatedArticles?: Array<{


### PR DESCRIPTION
## Summary

- **Sanity schema**: Added `tags` string-array field to the `article` document type (max 10 per article, tag-input layout in Studio). Tags use lowercase-hyphen convention and are designed to be fine-grained topics, people, places, or events.
- **Utility functions** (`src/lib/tagUtils.ts`): `tagToSlug`, `slugToTagLabel`, `tagPageUrl` for consistent tag-to-URL normalisation throughout the app.
- **GROQ queries**: `queryAllTags` (deduplicated flat array of all in-use tags) and `queryArticlesByTag` (articles by raw tag, ordered `publishedAt desc`) added to `queries.ts`. `queryAllArticles` updated to include `tags`.
- **Tag page route** (`src/app/(user)/tag/[slug]/page.tsx`): `generateStaticParams`, `generateMetadata` with canonical URL, CollectionPage JSON-LD, breadcrumb nav (Home > Tags > [Label]), `bg-untele` header bar with article count, `ArticleCardLg` grid, and empty state.
- **Article detail page**: "Filed Under" tag badge section added below the Sources panel — each badge links to `/tag/[slug]`. Section is hidden when `article.tags` is empty.
- **Sitemap**: All `/tag/[slug]` URLs added with `changeFrequency: 'daily'` and `priority: 0.5`.
- **Types**: `tags?: string[]` added to the global `Article` interface in `types.d.ts`.

## Test plan

- [ ] Add tags to an article in Sanity Studio — verify the tag-input UI appears and max-10 warning fires
- [ ] Visit `/tag/[any-tag-slug]` — confirm the page renders with article grid and correct breadcrumb
- [ ] Visit `/tag/nonexistent-tag` — confirm `notFound()` returns a 404
- [ ] Open any article that has tags — confirm "Filed Under" badges appear and link correctly to `/tag/[slug]`
- [ ] Check `/sitemap.xml` contains `/tag/` entries
- [ ] Run `npx tsc --noEmit` — no tag-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)