### PR TITLE
feat(analytics): conversion tracking for all forms + bookstore page events

### DIFF
--- a/src/app/(news)/donate/page.tsx
+++ b/src/app/(news)/donate/page.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/function-component-definition */
-// src/app/(user)/donate/page.tsx
+// src/app/(news)/donate/page.tsx
 import React from 'react';
 import Link from 'next/link';
 import type { Metadata } from 'next';
+import PageViewTracker from '@/components/analytics/PageViewTracker';
+import DonateLink from '@/components/donate/DonateLink';
 
 export const metadata: Metadata = {
   title: 'Support Independent Journalism',
@@ -13,6 +15,8 @@ export const metadata: Metadata = {
 export default function DonatePage() {
   return (
     <div className='min-h-screen bg-black text-slate-100'>
+      <PageViewTracker event='donate_intent' />
+
       {/* HERO SECTION */}
       <section className='border-b border-slate-800 bg-gradient-to-b from-slate-950 to-black py-16'>
         <div className='mx-auto max-w-7xl px-4'>
@@ -99,14 +103,13 @@ export default function DonatePage() {
               <p className='mb-4 flex-1 text-sm text-slate-300'>
                 Quick and secure mobile payments
               </p>
-              <a
+              <DonateLink
                 href='https://cash.app/$UnTelevisedMedia'
+                platform='cashapp'
                 className='bg-untele px-4 py-3 text-center text-sm font-black uppercase tracking-widest text-white transition-colors hover:bg-red-600'
-                target='_blank'
-                rel='noopener noreferrer'
               >
                 $UnTelevisedMedia
-              </a>
+              </DonateLink>
             </div>
 
             {/* Venmo */}
@@ -116,14 +119,13 @@ export default function DonatePage() {
               </div>
               <h4 className='mb-3 text-lg font-bold uppercase tracking-wide text-white'>VENMO</h4>
               <p className='mb-4 flex-1 text-sm text-slate-300'>Social payment platform</p>
-              <a
+              <DonateLink
                 href='https://venmo.com/UnTelevised'
+                platform='venmo'
                 className='bg-untele px-4 py-3 text-center text-sm font-black uppercase tracking-widest text-white transition-colors hover:bg-red-600'
-                target='_blank'
-                rel='noopener noreferrer'
               >
                 @UnTelevised
-              </a>
+              </DonateLink>
             </div>
 
             {/* Email Contact */}
@@ -211,14 +213,13 @@ export default function DonatePage() {
             bonuses, no shareholder profits—just fearless journalism.
           </p>
           <div className='flex flex-col gap-4 sm:flex-row sm:justify-center'>
-            <a
+            <DonateLink
               href='https://cash.app/$UnTelevisedMedia'
+              platform='cashapp'
               className='bg-untele px-8 py-4 text-sm font-black uppercase tracking-widest text-white transition-colors hover:bg-red-600'
-              target='_blank'
-              rel='noopener noreferrer'
             >
               DONATE NOW
-            </a>
+            </DonateLink>
             <Link
               href='/secure-contact'
               className='border-2 border-white bg-transparent px-8 py-4 text-center text-sm font-black uppercase tracking-widest text-white transition-colors hover:bg-white hover:text-black'

--- a/src/app/(news)/secure-contact/page.tsx
+++ b/src/app/(news)/secure-contact/page.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { Shield, Lock, Eye, AlertTriangle } from 'lucide-react';
 import { TurnstileWidget } from '@/components/global/TurnstileWidget';
+import { useConsentAwareTracking } from '@/components/analytics/ConsentAwareAnalytics';
 
 export default function SecureContactPage() {
   const [formData, setFormData] = useState({
@@ -21,6 +22,7 @@ export default function SecureContactPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const { trackEvent } = useConsentAwareTracking();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value, type } = e.target;
@@ -49,6 +51,11 @@ export default function SecureContactPage() {
       });
 
       if (response.ok) {
+        trackEvent('secure_contact_submitted', {
+          urgency: formData.urgency,
+          contact_method: formData.contactMethod,
+          is_anonymous: formData.isAnonymous,
+        });
         setSubmitStatus('success');
         setFormData({
           name: '',

--- a/src/app/(news)/whistleblower/page.tsx
+++ b/src/app/(news)/whistleblower/page.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { Eye, Shield, Lock, AlertTriangle, FileText } from 'lucide-react';
 import { TurnstileWidget } from '@/components/global/TurnstileWidget';
+import { useConsentAwareTracking } from '@/components/analytics/ConsentAwareAnalytics';
 
 export default function WhistleblowerPage() {
   const [formData, setFormData] = useState({
@@ -26,6 +27,7 @@ export default function WhistleblowerPage() {
   const [submitStatus, setSubmitStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [submissionId, setSubmissionId] = useState<string>('');
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const { trackEvent } = useConsentAwareTracking();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value, type } = e.target;
@@ -61,6 +63,12 @@ export default function WhistleblowerPage() {
       });
 
       if (response.ok) {
+        trackEvent('whistleblower_submitted', {
+          category: formData.category,
+          severity: formData.severity,
+          is_anonymous: formData.isAnonymous,
+          protection_needed: formData.protectionNeeded,
+        });
         setSubmitStatus('success');
         setSubmissionId(newSubmissionId);
         setFormData({

--- a/src/app/(user)/bookstore/downloads/page.tsx
+++ b/src/app/(user)/bookstore/downloads/page.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useConsentAwareTracking } from '@/components/analytics/ConsentAwareAnalytics';
 
 interface DownloadRecord {
   id: string;
@@ -19,9 +20,18 @@ interface DownloadRecord {
   } | null;
 }
 
-function DownloadButton({ orderItemId }: { orderItemId: string }) {
+function DownloadButton({
+  orderItemId,
+  bookTitle,
+  formatLabel,
+}: {
+  orderItemId: string;
+  bookTitle: string;
+  formatLabel: string;
+}) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { trackEvent } = useConsentAwareTracking();
 
   const handleDownload = async () => {
     setLoading(true);
@@ -33,6 +43,7 @@ function DownloadButton({ orderItemId }: { orderItemId: string }) {
         setError(data.error ?? 'Download failed');
         return;
       }
+      trackEvent('download_file', { book_title: bookTitle, format: formatLabel });
       window.location.href = data.url;
     } catch {
       setError('Network error — please try again');
@@ -59,19 +70,20 @@ export default function DownloadsPage() {
   const [downloads, setDownloads] = useState<DownloadRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { trackEvent } = useConsentAwareTracking();
 
   useEffect(() => {
-    // Fetch downloads from a lightweight internal API (or directly if using server actions)
-    // For now, we fetch from a simple endpoint that returns the user's download records
     fetch('/api/bookstore/my-downloads')
       .then(async (res) => {
         if (!res.ok) throw new Error('Failed to load downloads');
         const data = (await res.json()) as { downloads: DownloadRecord[] };
-        setDownloads(data.downloads ?? []);
+        const items = data.downloads ?? [];
+        setDownloads(items);
+        trackEvent('view_downloads', { download_count: items.length });
       })
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false));
-  }, []);
+  }, [trackEvent]);
 
   return (
     <main className='mx-auto max-w-4xl px-4 py-8 sm:px-6'>
@@ -149,7 +161,13 @@ export default function DownloadsPage() {
                     <p className='text-[10px] text-amber-500'>File being prepared — check back soon</p>
                   )}
                 </div>
-                {available && <DownloadButton orderItemId={dl.order_item_id} />}
+                {available && (
+                  <DownloadButton
+                    orderItemId={dl.order_item_id}
+                    bookTitle={dl.order_items?.book_title ?? 'Unknown'}
+                    formatLabel={dl.order_items?.format_label ?? 'digital'}
+                  />
+                )}
               </div>
             );
           })}

--- a/src/app/(user)/bookstore/orders/page.tsx
+++ b/src/app/(user)/bookstore/orders/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next';
 import { auth, currentUser } from '@clerk/nextjs/server';
 import { shopServiceClient } from '@/lib/bookstore/supabase';
 import type { Order, OrderItem } from '@/lib/bookstore/types';
+import PageViewTracker from '@/components/analytics/PageViewTracker';
 
 export const metadata: Metadata = {
   title: 'My Orders — Hurriya Publications',
@@ -87,6 +88,7 @@ export default async function OrdersPage() {
 
   return (
     <main className='mx-auto max-w-4xl px-4 py-8 sm:px-6'>
+      <PageViewTracker event='view_orders' params={{ order_count: (orders ?? []).length }} />
       <div className='mb-6 flex items-center gap-3'>
         <div className='bg-untele px-3 py-1'>
           <span className='text-sm font-black uppercase tracking-widest text-white'>

--- a/src/app/(user)/bookstore/page.tsx
+++ b/src/app/(user)/bookstore/page.tsx
@@ -18,6 +18,7 @@ import GenreFilter from '@/components/bookstore/GenreFilter';
 import BookCardActions from '@/components/bookstore/BookCardActions';
 import BookstoreNewsletter from '@/components/bookstore/BookstoreNewsletter';
 import WishlistButton from '@/components/bookstore/WishlistButton';
+import PageViewTracker from '@/components/analytics/PageViewTracker';
 
 export const metadata: Metadata = {
   title: 'Bookstore — Hurriya Publications',
@@ -228,6 +229,10 @@ export default async function ShopPage({
 
   return (
     <main className='mx-auto max-w-7xl px-4 py-8 sm:px-6'>
+      <PageViewTracker
+        event='view_bookstore_home'
+        params={{ featured_book_count: featured.length, total_book_count: allBooks.length }}
+      />
       {/* Page header */}
       <div className='mb-6 flex items-center gap-3'>
         <div className='bg-untele px-3 py-1'>

--- a/src/app/(user)/bookstore/wishlist/page.tsx
+++ b/src/app/(user)/bookstore/wishlist/page.tsx
@@ -2,13 +2,21 @@
 // src/app/(user)/bookstore/wishlist/page.tsx
 // Book wishlist page — reads from useWishlist hook (local + Sanity).
 
+import { useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useWishlist } from '@/hooks/useWishlist';
 import WishlistButton from '@/components/bookstore/WishlistButton';
+import { useConsentAwareTracking } from '@/components/analytics/ConsentAwareAnalytics';
 
 export default function WishlistPage() {
   const { wishlist, loading, ready } = useWishlist();
+  const { trackEvent } = useConsentAwareTracking();
+
+  useEffect(() => {
+    if (!ready || loading) return;
+    trackEvent('view_wishlist', { wishlist_item_count: wishlist.length });
+  }, [ready, loading, wishlist.length, trackEvent]);
 
   return (
     <main className='mx-auto max-w-7xl px-4 py-8 sm:px-6'>

--- a/src/components/analytics/PageViewTracker.tsx
+++ b/src/components/analytics/PageViewTracker.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useConsentAwareTracking } from './ConsentAwareAnalytics';
+
+interface Props {
+  event: string;
+  params?: Record<string, unknown>;
+}
+
+export default function PageViewTracker({ event, params }: Props) {
+  const { trackEvent } = useConsentAwareTracking();
+
+  useEffect(() => {
+    trackEvent(event, params);
+    // intentionally runs once on mount — params are stable at render time
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}

--- a/src/components/careers/ContributorApplicationForm.tsx
+++ b/src/components/careers/ContributorApplicationForm.tsx
@@ -3,6 +3,7 @@
 
 import React, { useState } from 'react';
 import { CheckCircle2, AlertCircle } from 'lucide-react';
+import { useConsentAwareTracking } from '@/components/analytics/ConsentAwareAnalytics';
 
 interface FormData {
   firstName: string;
@@ -79,6 +80,7 @@ interface Props {
 }
 
 export function ContributorApplicationForm({ prefilledPosition }: Props) {
+  const { trackEvent } = useConsentAwareTracking();
   const matchedPosition = prefilledPosition
     ? positions.find(
         (p) =>
@@ -168,6 +170,11 @@ export function ContributorApplicationForm({ prefilledPosition }: Props) {
         body: JSON.stringify(cleaned),
       });
       if (!res.ok) throw new Error('submission failed');
+      trackEvent('contributor_application_submitted', {
+        positions: formData.positionsOfInterest.join(','),
+        experience_level: formData.experienceLevel,
+        availability: formData.availability,
+      });
       setStatus('success');
     } catch {
       setStatus('error');

--- a/src/components/donate/DonateLink.tsx
+++ b/src/components/donate/DonateLink.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useConsentAwareTracking } from '@/components/analytics/ConsentAwareAnalytics';
+
+interface Props {
+  href: string;
+  platform: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export default function DonateLink({ href, platform, className, children }: Props) {
+  const { trackEvent } = useConsentAwareTracking();
+
+  return (
+    <a
+      href={href}
+      className={className}
+      target='_blank'
+      rel='noopener noreferrer'
+      onClick={() => trackEvent('donate_click', { platform })}
+    >
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds GA4 conversion tracking to all forms: Contributor Application, Secure Contact, Whistleblower Portal, and Donate link clicks
- Adds bookstore page-level events: `view_bookstore_home`, `view_wishlist`, `view_orders`, `view_downloads`
- Creates `PageViewTracker` reusable client component for firing page-level events from server components
- Creates `DonateLink` client wrapper for tracked outbound donation links

## New Events Tracked

| Form / Page | Event | Conversion? |
|---|---|---|
| Contributor Application | `contributor_application_submitted` | Yes |
| Secure Contact | `secure_contact_submitted` | Yes |
| Whistleblower Portal | `whistleblower_submitted` | Yes |
| Donate link clicks | `donate_click` | Yes |
| Bookstore home | `view_bookstore_home` | No |
| Bookstore wishlist | `view_wishlist` | No |
| Bookstore orders | `view_orders` | No |
| Bookstore downloads | `view_downloads` | No |

## GA4 Admin Actions Required

See the follow-up issue for all manual GA4/GTM setup tasks (marking conversions, custom dimensions, audiences).

Closes #88

## Test plan

- [ ] Verify events fire in GA4 DebugView for each form submission
- [ ] Verify `donate_click` fires on CashApp/Venmo link clicks
- [ ] Verify bookstore page-level events appear in DebugView
- [ ] Confirm no PII in whistleblower/secure-contact event parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)